### PR TITLE
fix code indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ HTML_EXTRA_STYLESHEET  = doxygen-awesome-theme/doxygen-awesome.css custom.css
 | `--border-radius-medium`  | `6px`  |
 | **Content Width**:<br>The content is centered and constraint in it's width. To make the content fill the whole page, set the following variable to `auto`. ||
 | `--content-maxwidth`      | `900px` |
-| **Code Fragment Wrapping Behaviour**:<br>By default code does not wrap (`nowrap`). Overflowing content can be scrolled. If you want code to wrap, set the following variable to `initial`. ||
-| `--fragment-whitespace` | `nowrap` |
 | **Code Fragment Colors**:<br>Color-Scheme of multiline codeblocks ||
 | `--fragment-background` | <span style="background:#282c34;color:white">#282c34</span> |
 | `--fragment-foreground` | <span style="background:#fff;wolor:black">#fff</span> |

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -141,7 +141,7 @@ SOFTWARE.
     --fragment-preprocessor: #65cabe;
     --fragment-linenumber-color: #ccc;
     --fragment-linenumber-background: #35393c;
-    --fragment-lineheight: 22px;
+    --fragment-lineheight: 20px;
 
     /* sidebar navigation (treeview) colors */
     --side-nav-background: var(--page-background-color);

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -883,6 +883,10 @@ div.fragment {
     line-height: 0;
 }
 
+div.line:after {
+    margin-right: var(--spacing-medium);
+}
+
 div.fragment .line, pre.fragment {
     white-space: pre;
     word-wrap: initial;

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -141,7 +141,8 @@ SOFTWARE.
     --fragment-preprocessor: #65cabe;
     --fragment-linenumber-color: #ccc;
     --fragment-linenumber-background: #35393c;
-    --fragment-whitespace: nowrap;
+    --fragment-whitespace: pre;
+    --fragment-lineheight: 22px;
 
     /* sidebar navigation (treeview) colors */
     --side-nav-background: var(--page-background-color);
@@ -884,8 +885,9 @@ div.fragment, div.fragment .line, div.fragment span {
     white-space: var(--fragment-whitespace);
 }
 
-div.line:after {
-    content: '';
+div.fragment .line {
+    display: inline-block;
+    line-height: var(--fragment-lineheight);
 }
 
 div.fragment span.keyword {

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -886,6 +886,7 @@ div.fragment, div.fragment .line, div.fragment span {
 
 div.fragment .line {
     display: inline-block;
+    word-wrap: initial;
     line-height: var(--fragment-lineheight);
 }
 

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -141,7 +141,6 @@ SOFTWARE.
     --fragment-preprocessor: #65cabe;
     --fragment-linenumber-color: #ccc;
     --fragment-linenumber-background: #35393c;
-    --fragment-whitespace: pre;
     --fragment-lineheight: 22px;
 
     /* sidebar navigation (treeview) colors */
@@ -882,7 +881,7 @@ code, code a, pre.fragment, div.fragment, div.fragment .line, div.fragment span 
 }
 
 div.fragment, div.fragment .line, div.fragment span {
-    white-space: var(--fragment-whitespace);
+    white-space: pre;
 }
 
 div.fragment .line {

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -874,18 +874,17 @@ div.fragment, pre.fragment {
     }
 }
 
-code, code a, pre.fragment, div.fragment, div.fragment .line, div.fragment span {
+code, code a, pre.fragment, div.fragment, div.fragment .line, div.fragment span, div.fragment .line a, div.fragment .line span {
     font-family: var(--font-family-monospace);
-    font-size: var(--code-font-size);
-    line-height: inherit;
+    font-size: var(--code-font-size) !important;
 }
 
-div.fragment, div.fragment .line, div.fragment span {
+div.fragment {
+    line-height: 0;
+}
+
+div.fragment .line, pre.fragment {
     white-space: pre;
-}
-
-div.fragment .line {
-    display: inline-block;
     word-wrap: initial;
     line-height: var(--fragment-lineheight);
 }

--- a/include/MyLibrary/example.hpp
+++ b/include/MyLibrary/example.hpp
@@ -51,8 +51,11 @@ public:
      *
      * @code{.cpp}
      * // code within @code block
-     * auto example = std::make_shared<Example>(5);
-     * example->test("test");
+     * if(true) {
+     *    auto example = std::make_shared<Example>(5);
+     *    example->test("test");
+     * }
+     * 
      * @endcode
      *
      *     // code within indented code block

--- a/include/MyLibrary/subclass-example.hpp
+++ b/include/MyLibrary/subclass-example.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include "example.hpp"
+#include <iostream>
 
 namespace MyLibrary {
 
@@ -13,7 +14,11 @@ namespace MyLibrary {
          */
         int virtualfunc() override;
 
-        std::shared_ptr<std::string> super_long_function_with_lots_of_parameters(std::shared_ptr<std::string>& text, std::shared_ptr<std::string>& text2);
+        std::shared_ptr<std::string> super_long_function_with_lots_of_parameters(std::shared_ptr<std::string>& text, std::shared_ptr<std::string>& text2) {
+            if(true) {
+                std::cout << "this even has some code." << std::endl;
+            }
+        }
 
     };
 


### PR DESCRIPTION
fixes #9 

This fixes the broken indentation, while code still does scroll if a line it too long.

The only downside: It creates a weird padding at the end of file listings, that I cannot explain. But I can live with that.

<img width="988" alt="Bildschirmfoto 2021-04-19 um 23 08 43" src="https://user-images.githubusercontent.com/21294002/115303798-5a606380-a164-11eb-9e45-42abb7512053.png">

Because the lines have to be `display: inline-block` instead of `block` to work well with `white-space: pre`, I had to remove the option to restore the default code wrapping behaviour (wrap line if too long).