### PR TITLE
Fix the shadows that style the code example line numbers

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -931,7 +931,7 @@ div.fragment span.lineno a {
 }
 
 div.fragment .line:first-child .lineno {
-    box-shadow: -9999px 0px 0 9999px var(--fragment-linenumber-background), -9998px 0px 0 9999px rgba(0,0,0,.3);
+    box-shadow: -999999px 0px 0 999999px var(--fragment-linenumber-background), -999998px 0px 0 999999px var(--fragment-linenumber-color);
 }
 
 /*


### PR DESCRIPTION
I was playing around with the color theme for the code examples and noticed that after 626 lines the formatting of the line number broke. You use some box shadows that extend 9999 pixels in two directions to style that area. Unfortunately with long code examples this is not enough since half a screen page on a FHD monitor is already around 500pixels. 

Also the second shadow that styles the "border" fencing off the line number area from the actual code area was a hardcoded color and wouldn't follow darkmode or any other color settings. I just swapped the hardcoded rgba value for the color of the actual line number, that gives enough contrast and looks nice.

![shadow_error](https://user-images.githubusercontent.com/4920542/117444932-66a53880-af3a-11eb-8266-72ec486a4574.png)

After extending the shadow area by a cool 990000 pixels to avoid future problems:
![shadow_error_million](https://user-images.githubusercontent.com/4920542/117444931-660ca200-af3a-11eb-80d8-0cbe7eb01fab.png)

