### PR TITLE
Hide #nav-tree scrollbars for chromium browsers

### DIFF
--- a/doxygen-awesome-sidebar-only.css
+++ b/doxygen-awesome-sidebar-only.css
@@ -56,6 +56,10 @@ html {
     #nav-tree {
         padding: 0;
     }
+    
+    #nav-tree::-webkit-scrollbar { 
+        display: none;
+    }
 
     #top {
         display: block;


### PR DESCRIPTION
The ::-webkit-scrollbar CSS extension will hide the scrollbars without disabling #nav-tree scrolling ability. 

https://user-images.githubusercontent.com/83611172/129077130-d71d2fa4-2116-4f06-8109-fd71951a3579.mp4

