### PR TITLE
Fix code font-size in function declarations

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -1181,6 +1181,7 @@ div.memtitle {
 
 div.memproto table.memname {
     font-family: monospace, fixed;
+    font-size: var(--code-font-size) !important;
     color: var(--page-foreground-color);
 }
 


### PR DESCRIPTION
The font size in function declarations was rendered in `--page-font-size` before. This was a bit large and inconsistent with code in other places, so this change fixes it to `--code-font-size`.