### PR TITLE
feat: make the project installable with a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 Andrea Pappacoda <andrea@pappacoda.it>
+# SPDX-License-Identifier: MIT
+
+.POSIX:
+
+PROJECT = doxygen-awesome-css
+
+# Paths
+PREFIX = /usr/local
+DATADIR = share
+INSTALLDIR = $(DESTDIR)$(PREFIX)/$(DATADIR)/$(PROJECT)
+
+# Utilities
+INSTALL = install -m 644
+MKDIR = mkdir -p
+RM = rm -f
+
+# Files to be installed
+FILES = doxygen-awesome-darkmode-toggle.js \
+  doxygen-awesome-fragment-copy-button.js \
+  doxygen-awesome-interactive-toc.js \
+  doxygen-awesome-paragraph-link.js \
+  doxygen-awesome-sidebar-only-darkmode-toggle.css \
+  doxygen-awesome-sidebar-only.css \
+  doxygen-awesome.css
+
+# Empty targets so that `make` and `make clean` do not cause errors
+all:
+clean:
+
+install:
+	$(MKDIR) $(INSTALLDIR)
+	$(INSTALL) $(FILES) $(INSTALLDIR)/
+
+uninstall:
+	$(RM) -r $(INSTALLDIR)/
+
+.PHONY: all clean install uninstall

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some websites using this theme:
 - [Spatial Audio Framework (SAF)](https://leomccormack.github.io/Spatial_Audio_Framework/index.html)
 - [libCloudSync](https://jothepro.github.io/libCloudSync/)
 - [libsl3](https://a4z.github.io/libsl3/)
- 
+
 ## Installation
 
 To use the theme in your documentation, copy the required CSS and JS files from this repository into your project or add the repository as submodule and check out the latest release:
@@ -49,6 +49,8 @@ git submodule add https://github.com/jothepro/doxygen-awesome-css.git
 cd doxygen-awesome-css
 git checkout v2.1.0
 ```
+
+You can even install the theme system-wide by running `make install`. The files will be installed to `/usr/local/share/` by default, but you can customize the install location with `make PREFIX=/my/custom/path install`.
 
 All theme files are located in the root of this repository and start with the prefix `doxygen-awesome-`. You may not need all of them. Follow the install instructions to figure out what files are required for your setup.
 


### PR DESCRIPTION
This patch adds a small POSIX Makefile so that Doxygen Awesome can be easily installed, by running `make install`.

The file works on Linux, BSDs, macOS, and possibly even Windows.

This is mostly useful for distributions, so that they can easily package this project in a uniform way; in fact, I wrote this because I'm packaging Doxygen Awesome for Debian :)

A default installation would look like this:

    $ tree usr
    usr
    └── local
       └── share
          └── doxygen-awesome-css
             ├── doxygen-awesome-darkmode-toggle.js
             ├── doxygen-awesome-fragment-copy-button.js
             ├── doxygen-awesome-interactive-toc.js
             ├── doxygen-awesome-paragraph-link.js
             ├── doxygen-awesome-sidebar-only-darkmode-toggle.css
             ├── doxygen-awesome-sidebar-only.css
             └── doxygen-awesome.css