### PR TITLE
Enable dark mode for doxygen \image

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -955,6 +955,7 @@ div.contents div.dyncontent {
     html:not(.light-mode) div.contents center img,
     html:not(.light-mode) div.contents > table img,
     html:not(.light-mode) div.contents div.dyncontent iframe,
+    html:not(.light-mode) div.contents div.image > object,
     html:not(.light-mode) div.contents center iframe,
     html:not(.light-mode) div.contents table iframe {
         filter: hue-rotate(180deg) invert();
@@ -965,6 +966,7 @@ html.dark-mode div.contents div.dyncontent img,
 html.dark-mode div.contents center img,
 html.dark-mode div.contents > table img,
 html.dark-mode div.contents div.dyncontent iframe,
+html.dark-mode div.contents div.image > object,
 html.dark-mode div.contents center iframe,
 html.dark-mode div.contents table iframe {
     filter: hue-rotate(180deg) invert();

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -955,7 +955,8 @@ div.contents div.dyncontent {
     html:not(.light-mode) div.contents center img,
     html:not(.light-mode) div.contents > table img,
     html:not(.light-mode) div.contents div.dyncontent iframe,
-    html:not(.light-mode) div.contents div.image > object,
+    html:not(.light-mode) div.contents div.image > object, /* apply dark schema also to the \image tag, at least for svg */
+    html:not(.light-mode) div.contents div.image > img, /* apply dark schema also to the \image tag, at least for svg */
     html:not(.light-mode) div.contents center iframe,
     html:not(.light-mode) div.contents table iframe {
         filter: hue-rotate(180deg) invert();
@@ -966,7 +967,8 @@ html.dark-mode div.contents div.dyncontent img,
 html.dark-mode div.contents center img,
 html.dark-mode div.contents > table img,
 html.dark-mode div.contents div.dyncontent iframe,
-html.dark-mode div.contents div.image > object,
+html.dark-mode div.contents div.image > object, /* apply dark schema also to the \image tag, at least for svg */
+html.dark-mode div.contents div.image > img, /* apply dark schema also to the \image tag, at least for svg */
 html.dark-mode div.contents center iframe,
 html.dark-mode div.contents table iframe {
     filter: hue-rotate(180deg) invert();


### PR DESCRIPTION
Doxygen can add custom images to the documentation using the \image command. The css is extended to enable dark mode for such images, like already done for the "dot" generated SVG inheritance diagrams.

(Tested only with SVG images defined using the \image command)