### PR TITLE
Fix typo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,3 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
-# how use
-# pip3 install pre-commit
-# pre-commit run --all-files --verbose
-#
-# ❯ pre-commit run --all-files --verbose
-# codespell................................................................Failed
-# - hook id: codespell
-# - duration: 0.2s
-# - exit code: 65
-
-# docs/tricks.md:47: choosen ==> chosen
-# docs/customization.md:29: wether ==> weather, whether
-# doxygen-awesome.css:163: collapsable ==> collapsible

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+# how use
+# pip3 install pre-commit
+# pre-commit run --all-files --verbose
+#
+# ❯ pre-commit run --all-files --verbose
+# codespell................................................................Failed
+# - hook id: codespell
+# - duration: 0.2s
+# - exit code: 65
+
+# docs/tricks.md:47: choosen ==> chosen
+# docs/customization.md:29: wether ==> weather, whether
+# doxygen-awesome.css:163: collapsable ==> collapsible

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -26,7 +26,7 @@ html {
 }
 ```
 
-For dark-mode overrides you have to choose where to put them, depending on wether the dark-mode toggle extension is installed or not:
+For dark-mode overrides you have to choose where to put them, depending on whether the dark-mode toggle extension is installed or not:
 
 - dark-mode toggle is installed:
     ```css

--- a/docs/tricks.md
+++ b/docs/tricks.md
@@ -44,7 +44,7 @@ html {
 }
 ```
 
-The choosen width should also be set in the Doxyfile:
+The chosen width should also be set in the Doxyfile:
 
 ```
 # Doxyfile

--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -160,7 +160,7 @@ html {
     --toc-background: var(--side-nav-background);
     --toc-foreground: var(--side-nav-foreground);
 
-    /* height of an item in any tree / collapsable table */
+    /* height of an item in any tree / collapsible table */
     --tree-item-height: 30px;
 
     --memname-font-size: var(--code-font-size);


### PR DESCRIPTION

It was a pretty amazing project and I loved it, but I found some typos, so I fixed them and provided spell-checking hooks，hopefully that was useful。


```txt
# how use
# pip3 install pre-commit
# pre-commit run --all-files --verbose
#
# ❯ pre-commit run --all-files --verbose
# codespell................................................................Failed
# - hook id: codespell
# - duration: 0.2s
# - exit code: 65

# docs/tricks.md:47: choosen ==> chosen
# docs/customization.md:29: wether ==> weather, whether
# doxygen-awesome.css:163: collapsable ==> collapsible

```