### PR TITLE
Add previous button

### DIFF
--- a/doxygen-custom/custom.css
+++ b/doxygen-custom/custom.css
@@ -25,6 +25,11 @@
     text-decoration: none;
 }
 
+.section_buttons {
+    display: flex;
+    justify-content: space-between;
+}
+
 .next_section_button {
     display: block;
     padding: var(--spacing-large) 0 var(--spacing-small) 0;
@@ -67,6 +72,50 @@
 .next_section_button a:hover::after {
     color: var(--page-foreground-color) !important;
     transform: translateX(3px);
+}
+
+.previous_section_button {
+    display: block;
+    padding: var(--spacing-large) 0 var(--spacing-small) 0;
+    color: var(--page-background-color);
+    user-select: none;
+}
+
+.previous_section_button::after {
+    /* clearfix */
+    content: "";
+    clear: both;
+    display: table;
+}
+
+.previous_section_button a {
+    overflow: hidden;
+    float: left;
+    border: 1px solid var(--separator-color);
+    padding: var(--spacing-medium) var(--spacing-large) var(--spacing-medium) calc(var(--spacing-large) / 2);
+    border-radius: var(--border-radius-medium);
+    color: var(--page-secondary-foreground-color) !important;
+    text-decoration: none;
+    background-color: var(--page-background-color);
+    transition: color .08s ease-in-out, background-color .1s ease-in-out;
+}
+
+.previous_section_button a:hover {
+    color: var(--page-foreground-color) !important;
+    background-color: var(--odd-color);
+}
+
+.previous_section_button a::before {
+    content: '〈';
+    color: var(--page-secondary-foreground-color) !important;
+    padding-right: var(--spacing-large);
+    display: inline-block;
+    transition: color .08s ease-in-out, transform .09s ease-in-out;
+}
+
+.previous_section_button a:hover::before {
+    color: var(--page-foreground-color) !important;
+    transform: translateX(-3px);
 }
 
 .alter-theme-button:hover {


### PR DESCRIPTION
I like the next button defined in `custom.css` but I needed previous button. 

This PR add `previous button` classes and also a `section_buttons` class to arrange buttons nicely when you have both previous and next buttons.

## Setup

Add `custom.css` to the `HTML_EXTRA_STYLESHEET` of the Doxygen configuration file:

```
HTML_EXTRA_STYLESHEET  = doxygen-awesome.css custom.css
```
## How to use?

### Previous or next button
Add a `span` with the right class, `previous_section_button` or `next_section_button`:
```html
<span class="previous_section_button">
Read Previous: [Firmware](firmware.md)
</span>
```

### Previous and next buttons

If you want to have both buttons, just add an enclosing `div` with `section_buttons` class: 

```html
<div class="section_buttons">
<span class="previous_section_button">
Read Previous: [Hardware](hardware.md)
</span>
<span class="next_section_button">
Read Next: [Settings](settings.md)
</span>
</div>
```