### PR TITLE
Give the search field spyglass icon more breathing room

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -619,6 +619,7 @@ a.anchor {
     height: calc(var(--searchbar-height) - 2px);
     background: transparent;
     width: calc(var(--searchbar-width) - 64px);
+    margin: 0 0.5em;
 }
 
 .MSearchBoxActive #MSearchField {


### PR DESCRIPTION
Thanks for the excellent project! It really does make Doxygen look so much better.

By default the search input field in doxygen-awesome-css has a 0.15em margin with the MSearchSelectExt spyglass icon which is fine in the default CSS, but here it's a bit cramped. Bumping up to a reasonable margin makes everything pretty again.