### PR TITLE
feat: add readthedocs javascript search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs/html
+_readthedocs
 .DS_Store
 .idea
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+---
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "miniconda-latest"
+  commands:
+    - chmod +x readthedocs_build.sh
+    - ./readthedocs_build.sh
+
+# using conda, we can get newer doxygen and graphviz than ubuntu provide
+# https://github.com/readthedocs/readthedocs.org/issues/8151#issuecomment-890359661
+conda:
+  environment: environment.yml

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -238,6 +238,39 @@ Each item in the list must start with an element that has the class `tab-title`.
 </div>
 ```
 
+## Read the Docs search {#readthedocs-search}
+
+Use search index from Read the Docs instead of the built-in doxygen search. This allows using search metrics from
+Read the Docs and in general gives a better search experience.
+
+### Installation
+
+1. Add the required resources in your `Doxyfile`:
+   - **HTML_EXTRA_FILES:** `doxygen-awesome-readthedocs-search.js`
+   - **HTML_EXTRA_STYLESHEET:** `doxygen-awesome-readthedocs-search.css`
+   - **SEARCHENGINE:** `YES`
+   - **SERVER_BASED_SEARCH:** `YES`
+   - **EXTERNAL_SEARCH:** `YES`
+   - **SEARCHENGINE_URL:** `https://<your-project>.readthedocs.io/` OR
+   - **SEARCHENGINE_URL:** `https://<your-custom-readthedocs-domain>/`
+
+   `SEARCHENGINE_URL` is only used when testing locally, otherwise the domain name is detected automatically.
+   When testing locally, search may not work without disabling CORS. This can be a security risk, so it is advised to
+   only test inside of Read the Docs.
+
+2. In the `header.html` template, include `doxygen-awesome-readthedocs-search.js` at the end of the `<head>` and then initialize it:
+    ```html
+   <html> 
+       <head>
+           <!-- ... other metadata & script includes ... -->
+           <script type="text/javascript" src="$relpath^doxygen-awesome-readthedocs-search.js"></script>
+           <script type="text/javascript">
+               DoxygenAwesomeReadtheDocsSearch.init()
+           </script>
+       </head>
+       <body>
+    ```
+
 ## Page Navigation {#extension-page-navigation}
 
 @warning Experimental feature! Please report bugs [here](https://github.com/jothepro/doxygen-awesome-css/issues).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -241,6 +241,39 @@ Each item in the list must start with an element that has the class `tab-title`.
 </div>
 ```
 
+## Read the Docs search {#readthedocs-search}
+
+Use search index from Read the Docs instead of the built-in doxygen search. This allows using search metrics from
+Read the Docs and in general gives a better search experience.
+
+### Installation
+
+1. Add the required resources in your `Doxyfile`:
+   - **HTML_EXTRA_FILES:** `doxygen-awesome-readthedocs-search.js`
+   - **HTML_EXTRA_STYLESHEET:** `doxygen-awesome-readthedocs-search.css`
+   - **SEARCHENGINE:** `YES`
+   - **SERVER_BASED_SEARCH:** `YES`
+   - **EXTERNAL_SEARCH:** `YES`
+   - **SEARCHENGINE_URL:** `https://<your-project>.readthedocs.io/` OR
+   - **SEARCHENGINE_URL:** `https://<your-custom-readthedocs-domain>/`
+
+   `SEARCHENGINE_URL` is only used when testing locally, otherwise the domain name is detected automatically.
+   When testing locally, search may not work without disabling CORS. This can be a security risk, so it is advised to
+   only test inside of Read the Docs.
+
+2. In the `header.html` template, include `doxygen-awesome-readthedocs-search.js` at the end of the `<head>` and then initialize it:
+    ```html
+   <html> 
+       <head>
+           <!-- ... other metadata & script includes ... -->
+           <script type="text/javascript" src="$relpath^doxygen-awesome-readthedocs-search.js"></script>
+           <script type="text/javascript">
+               DoxygenAwesomeReadtheDocsSearch.init()
+           </script>
+       </head>
+       <body>
+    ```
+
 ## Page Navigation {#extension-page-navigation}
 
 To allow users to easily navigate from one document to another, "Next" and "Previous" buttons can be added at the end of a Markdown document.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -270,6 +270,12 @@ Read the Docs and in general gives a better search experience.
        </head>
        <body>
     ```
+   For the sidebar-only theme variant, initialize with left-aligned live results:
+    ```html
+   <script type="text/javascript">
+       DoxygenAwesomeReadtheDocsSearch.init('leftAlign')
+   </script>
+    ```
 
 ## Page Navigation {#extension-page-navigation}
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -273,6 +273,12 @@ Read the Docs and in general gives a better search experience.
        </head>
        <body>
     ```
+   For the sidebar-only theme variant, initialize with left-aligned live results:
+    ```html
+   <script type="text/javascript">
+       DoxygenAwesomeReadtheDocsSearch.init('leftAlign')
+   </script>
+    ```
 
 ## Page Navigation {#extension-page-navigation}
 

--- a/doxygen-awesome-readthedocs-search.css
+++ b/doxygen-awesome-readthedocs-search.css
@@ -1,0 +1,20 @@
+/* Highlight text in search results */
+span.highlighted {
+    background-color:var(--warning-color);
+    color: var(--page-foreground-color);
+    padding: 2px;
+    border-radius: 3px;
+}
+
+/* Remove list bullets for search results */
+ul.search {
+    list-style-type: none;
+    padding: 0;
+}
+
+/* Add horizontal divider for search results */
+ul.search li.search-result {
+    border-bottom: 1px solid var(--separator-color);
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}

--- a/doxygen-awesome-readthedocs-search.css
+++ b/doxygen-awesome-readthedocs-search.css
@@ -18,3 +18,70 @@ ul.search li.search-result {
     padding-bottom: 10px;
     margin-bottom: 10px;
 }
+
+/* Live search dropdown */
+#RTDLiveResults {
+    display: none;
+    position: absolute;
+    z-index: 10000;
+    left: unset;
+    background: var(--page-background-color);
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-large);
+    box-shadow: var(--box-shadow);
+    max-height: 420px;
+    overflow-y: auto;
+}
+
+#RTDLiveResults .rtd-live-list {
+    list-style: none;
+    margin: 0;
+    padding: var(--spacing-small) 0;
+}
+
+#RTDLiveResults .rtd-live-list li {
+    margin: 0;
+}
+
+#RTDLiveResults .rtd-live-item {
+    display: block;
+    padding: var(--spacing-small) var(--spacing-medium);
+    color: var(--page-foreground-color);
+    text-decoration: none;
+    outline: none;
+}
+
+#RTDLiveResults .rtd-live-item:hover,
+#RTDLiveResults .rtd-live-item:focus {
+    background: var(--menu-focus-background);
+    color: var(--menu-focus-foreground);
+}
+
+#RTDLiveResults .rtd-live-title {
+    display: block;
+    font-weight: bold;
+    font-size: var(--navigation-font-size);
+}
+
+#RTDLiveResults .rtd-live-snippet {
+    display: block;
+    font-size: calc(var(--navigation-font-size) * 0.9);
+    color: var(--page-secondary-foreground-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 400px;
+}
+
+#RTDLiveResults .rtd-live-snippet mark {
+    background-color: var(--warning-color);
+    color: var(--page-foreground-color);
+    padding: 0 2px;
+    border-radius: 2px;
+}
+
+#RTDLiveResults .rtd-live-empty {
+    padding: var(--spacing-medium);
+    color: var(--page-secondary-foreground-color);
+    font-size: var(--navigation-font-size);
+}

--- a/doxygen-awesome-readthedocs-search.css
+++ b/doxygen-awesome-readthedocs-search.css
@@ -21,6 +21,7 @@ ul.search li.search-result {
 
 /* Live search dropdown */
 #RTDLiveResults {
+    margin-top: var(--spacing-small);
     display: none;
     position: absolute;
     z-index: 10000;
@@ -31,6 +32,13 @@ ul.search li.search-result {
     box-shadow: var(--box-shadow);
     max-height: 420px;
     overflow-y: auto;
+}
+
+@media screen and (max-width: 767px) {
+    #RTDLiveResults {
+        left: var(--spacing-medium);
+        right: var(--spacing-medium);
+    }
 }
 
 #RTDLiveResults .rtd-live-list {
@@ -46,6 +54,8 @@ ul.search li.search-result {
 #RTDLiveResults .rtd-live-item {
     display: block;
     padding: var(--spacing-small) var(--spacing-medium);
+    margin: var(--spacing-small);
+    border-radius: var(--border-radius-small);
     color: var(--page-foreground-color);
     text-decoration: none;
     outline: none;
@@ -54,7 +64,6 @@ ul.search li.search-result {
 #RTDLiveResults .rtd-live-item:hover,
 #RTDLiveResults .rtd-live-item:focus {
     background: var(--menu-focus-background);
-    color: var(--menu-focus-foreground);
 }
 
 #RTDLiveResults .rtd-live-title {
@@ -71,6 +80,13 @@ ul.search li.search-result {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 400px;
+}
+
+#RTDLiveResults .rtd-live-item:hover .rtd-live-title,
+#RTDLiveResults .rtd-live-item:hover .rtd-live-snippet,
+#RTDLiveResults .rtd-live-item:focus .rtd-live-title,
+#RTDLiveResults .rtd-live-item:focus .rtd-live-snippet {
+    color: var(--menu-focus-foreground);
 }
 
 #RTDLiveResults .rtd-live-snippet mark {

--- a/doxygen-awesome-readthedocs-search.js
+++ b/doxygen-awesome-readthedocs-search.js
@@ -1,0 +1,172 @@
+class DoxygenAwesomeReadtheDocsSearch {
+  static searchResultsText=[
+    "Sorry, no pages matching your query.",
+    "Search finished, found <b>1</b> page matching the search query.",
+    "Search finished, found <b>$num</b> pages matching the search query.",
+  ];
+
+  static get serverUrl() {
+    const serverUrlSuffix = '_/api/v3/';
+    const domainName = window.location.hostname;
+    console.log(`Domain name: ${domainName}`);
+
+    if (domainName === 'localhost') {
+      let tmpServerUrl = serverUrl;
+      while (tmpServerUrl.endsWith('/')) {
+        tmpServerUrl = tmpServerUrl.slice(0, -1);
+      }
+      console.warn('Localhost detected, you probably need to bypass CORS');
+      return `${tmpServerUrl}/${serverUrlSuffix}`;
+    }
+    return `https://${domainName}/${serverUrlSuffix}`;
+  }
+
+  static init() {
+    window.searchFor = function(query, page, count) {
+      const results = $('#searchresults');
+
+      // Get the title
+      let pageTitle = $('div.title')
+      const originalTitle = pageTitle.text().toString();
+      let pageTitleStates = ["Searching", "Searching .", "Searching ..", "Searching ..."];
+      let pageTitleIndex = 0;
+
+      // Function to update the page title
+      function updatePageTitle() {
+        pageTitle.text(pageTitleStates[pageTitleIndex]);
+        pageTitleIndex = (pageTitleIndex + 1) % pageTitleStates.length;
+      }
+
+      // Start the interval to update the page title
+      let titleInterval = setInterval(updatePageTitle, 500);
+
+      // The summary will be displayed at the top of the search results
+      let resultSummary = document.createElement('p');
+      resultSummary.className = 'search-summary';
+      results.append(resultSummary);
+
+      // Put all results into an unordered list
+      let resultList = document.createElement('ul');
+      resultList.className = 'search';
+      results.append(resultList);
+
+      // readthedocs metadata
+      // TODO: how to handle defaults? ... only matters when this is outside of readthedocs
+      let projectSlug = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-project-slug") || "doxygen-awesome-css";
+      let projectVersion = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-version") || "latest";
+
+      // pull requests are not indexed, so use the default version
+      if (/^\d+$/.test(projectVersion)) {
+        console.log('Pull request detected, getting default version from ReadTheDocs API');
+        DoxygenAwesomeReadtheDocsSearch.getReadTheDocsDefaultVersion(projectSlug);
+      }
+
+      let url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}search/?q=project:${projectSlug}/${projectVersion}+${query}&page=${page + 1}&page_size=${count}`;
+      console.log(url);
+
+      let firstUrl = true;
+
+      function fetchResults(url) {
+        $.ajax({
+          url: url,
+          dataType: 'json',
+          success: function (data) {
+            // Add the query to the search field
+            // This seems only be working if applied in the ajax success function...
+            // maybe the field is not available before this point
+            $('#MSearchField').val(query);
+
+            if (firstUrl) {
+              if (data.count > 0) {
+                if (data.count === 1) {
+                  resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[1];
+                } else {
+                  resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[2].replace(/\$num/, data.count);
+                }
+              } else {
+                resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[0];
+              }
+            }
+
+            $.each(data.results, function (i, item) {
+              let resultItem = document.createElement('li');
+              resultItem.className = 'search-result';
+              let resultItemUrl = `${item.domain}${item.path}`;
+              let resultItemTitle = item.title;
+              let resultItemType = item.type;  // todo... we can possibly display results differently based on type
+              let resultItemTitleLink = document.createElement('a');
+              let resultItemTitleHeading = document.createElement('h3');
+              resultItemTitleHeading.appendChild(resultItemTitleLink);
+              resultItemTitleLink.href = resultItemUrl;
+              resultItemTitleLink.textContent = resultItemTitle;
+              resultItem.append(resultItemTitleHeading);
+              resultList.append(resultItem);
+
+              let resultItemParagraph = document.createElement('p');
+              resultItemParagraph.className = 'context';
+              for (let i = 0; i < item.blocks.length; i++) {
+                let blockContent = item.blocks[i].highlights.content.join(', ');
+
+                // Find all <span> tags and ensure they are highlighted
+                blockContent = blockContent.replace(/<span>(.*?)<\/span>/g, '<span class="highlighted">$1</span>');
+                resultItemParagraph.innerHTML += blockContent;
+
+                let blockName = `#${item.blocks[i].title.toLowerCase().replace(' ', '-')}`;
+                let blockUrl = resultItemUrl + blockName;
+                let blockLink = document.createElement('a');
+                blockLink.href = blockUrl;
+                blockLink.textContent = "More...";
+                resultItemParagraph.append(document.createTextNode(' '));
+                resultItemParagraph.append(blockLink);
+                resultItemParagraph.append(document.createElement('br'));
+              }
+              resultItem.append(resultItemParagraph);
+            });
+
+            // Add pagination
+            firstUrl = false;
+            if (data.next) {
+              fetchResults(data.next);
+            } else {
+              // Clear the interval when the search is complete
+              clearInterval(titleInterval);
+              pageTitle.text(originalTitle);
+            }
+          }
+        });
+      }
+
+      fetchResults(url);
+    }
+  }
+
+  // Function to extract the value of a specified Read the Docs meta property
+  static getMetaValue(propertyName) {
+    const metaTags = document.getElementsByTagName('meta');
+
+    for (let meta of metaTags) {
+      if (meta.name === propertyName) {
+        return meta.content;
+      }
+    }
+
+    return null;
+  }
+
+  static getReadTheDocsDefaultVersion(project) {
+    let url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}projects/${project}/`;
+    $.ajax({
+      url: url,
+      dataType: 'json',
+      success: function(data) {
+        console.log(data);
+        return data.default_version;
+      },
+      error: function(jqXHR, textStatus, errorThrown) {
+        console.error('Error:', textStatus, errorThrown);
+        console.log(`Cannot determine default version for ${project}, assuming "latest"`);
+        return "latest";
+      }
+    })
+  }
+}

--- a/doxygen-awesome-readthedocs-search.js
+++ b/doxygen-awesome-readthedocs-search.js
@@ -53,7 +53,7 @@ class DoxygenAwesomeReadtheDocsSearch {
       // readthedocs metadata
       // TODO: how to handle defaults? ... only matters when this is outside of readthedocs
       let projectSlug = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-project-slug") || "doxygen-awesome-css";
-      let projectVersion = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-version") || "latest";
+      let projectVersion = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-version-slug") || "latest";
 
       // pull requests are not indexed, so use the default version
       if (/^\d+$/.test(projectVersion)) {

--- a/doxygen-awesome-readthedocs-search.js
+++ b/doxygen-awesome-readthedocs-search.js
@@ -7,7 +7,7 @@ class DoxygenAwesomeReadtheDocsSearch {
 
   static get serverUrl() {
     const serverUrlSuffix = '_/api/v3/';
-    const domainName = window.location.hostname;
+    const domainName = globalThis.location.hostname;
     console.log(`Domain name: ${domainName}`);
 
     if (domainName === 'localhost') {
@@ -22,7 +22,68 @@ class DoxygenAwesomeReadtheDocsSearch {
   }
 
   static init() {
-    window.searchFor = function(query, page, count) {
+    const realSearchBox = globalThis.SearchBox;
+    globalThis.SearchBox = function(name, resultsPath, extension) {
+      if (realSearchBox) {
+        realSearchBox.call(this, name, resultsPath, extension);
+      }
+
+      this.OnSearchFieldFocus = function() {};
+
+      const originalClose = this.CloseResultsWindow;
+      this.CloseResultsWindow = function() {
+        if (originalClose) {
+          originalClose.call(this);
+        }
+        const field = this.DOMSearchField ? this.DOMSearchField() : null;
+        if (field?.id === document.activeElement?.id) {
+          return;
+        }
+      };
+    };
+
+    // Re-focus the search input if it is replaced in the DOM while focused.
+    // On mobile, viewport resize (triggered by the OSK opening) can cause
+    // menu.js resetState() to recreate the input element, losing focus.
+    const observer = new MutationObserver(function() {
+      const field = document.getElementById('MSearchField');
+      if (field && DoxygenAwesomeReadtheDocsSearch._searchFieldHadFocus) {
+        field.focus();
+      }
+    });
+
+    if (document.body) {
+      observer.observe(document.body, { childList: true, subtree: true });
+      DoxygenAwesomeReadtheDocsSearch._attachLiveSearch();
+    } else {
+      document.addEventListener('DOMContentLoaded', function() {
+        observer.observe(document.body, { childList: true, subtree: true });
+        DoxygenAwesomeReadtheDocsSearch._attachLiveSearch();
+      });
+    }
+
+    document.addEventListener('focusin', function(e) {
+      if (e.target?.id === 'MSearchField') {
+        DoxygenAwesomeReadtheDocsSearch._searchFieldHadFocus = true;
+      }
+    });
+    document.addEventListener('focusout', function(e) {
+      if (e.target?.id === 'MSearchField') {
+        setTimeout(function() {
+          DoxygenAwesomeReadtheDocsSearch._searchFieldHadFocus = false;
+        }, 0);
+      }
+    });
+
+    document.addEventListener('click', function(e) {
+      const dropdown = document.getElementById('RTDLiveResults');
+      const field = document.getElementById('MSearchField');
+      if (dropdown && !dropdown.contains(e.target) && e.target !== field) {
+        DoxygenAwesomeReadtheDocsSearch._hideLiveResults();
+      }
+    });
+
+    globalThis.searchFor = function(query, page, count) {
       const results = $('#searchresults');
 
       // Get the title
@@ -51,93 +112,247 @@ class DoxygenAwesomeReadtheDocsSearch {
       results.append(resultList);
 
       // readthedocs metadata
-      // TODO: how to handle defaults? ... only matters when this is outside of readthedocs
       let projectSlug = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-project-slug") || "doxygen-awesome-css";
       let projectVersion = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-version-slug") || "latest";
 
+      const ctx = {
+        query, resultSummary, resultList, titleInterval, pageTitle, originalTitle, firstUrl: true
+      };
+
       // pull requests are not indexed, so use the default version
-      if (/^\d+$/.test(projectVersion)) {
-        console.log('Pull request detected, getting default version from ReadTheDocs API');
-        DoxygenAwesomeReadtheDocsSearch.getReadTheDocsDefaultVersion(projectSlug);
-      }
+      const versionReady = /^\d+$/.test(projectVersion)
+          ? DoxygenAwesomeReadtheDocsSearch.getReadTheDocsDefaultVersion(projectSlug)
+          : Promise.resolve(projectVersion);
 
-      let url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}search/?q=project:${projectSlug}/${projectVersion}+${query}&page=${page + 1}&page_size=${count}`;
-      console.log(url);
-
-      let firstUrl = true;
-
-      function fetchResults(url) {
-        $.ajax({
-          url: url,
-          dataType: 'json',
-          success: function (data) {
-            // Add the query to the search field
-            // This seems only be working if applied in the ajax success function...
-            // maybe the field is not available before this point
-            $('#MSearchField').val(query);
-
-            if (firstUrl) {
-              if (data.count > 0) {
-                if (data.count === 1) {
-                  resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[1];
-                } else {
-                  resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[2].replace(/\$num/, data.count);
-                }
-              } else {
-                resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[0];
-              }
-            }
-
-            $.each(data.results, function (i, item) {
-              let resultItem = document.createElement('li');
-              resultItem.className = 'search-result';
-              let resultItemUrl = `${item.domain}${item.path}`;
-              let resultItemTitle = item.title;
-              let resultItemType = item.type;  // todo... we can possibly display results differently based on type
-              let resultItemTitleLink = document.createElement('a');
-              let resultItemTitleHeading = document.createElement('h3');
-              resultItemTitleHeading.appendChild(resultItemTitleLink);
-              resultItemTitleLink.href = resultItemUrl;
-              resultItemTitleLink.textContent = resultItemTitle;
-              resultItem.append(resultItemTitleHeading);
-              resultList.append(resultItem);
-
-              let resultItemParagraph = document.createElement('p');
-              resultItemParagraph.className = 'context';
-              for (let i = 0; i < item.blocks.length; i++) {
-                let blockContent = item.blocks[i].highlights.content.join(', ');
-
-                // Find all <span> tags and ensure they are highlighted
-                blockContent = blockContent.replace(/<span>(.*?)<\/span>/g, '<span class="highlighted">$1</span>');
-                resultItemParagraph.innerHTML += blockContent;
-
-                let blockName = `#${item.blocks[i].title.toLowerCase().replace(' ', '-')}`;
-                let blockUrl = resultItemUrl + blockName;
-                let blockLink = document.createElement('a');
-                blockLink.href = blockUrl;
-                blockLink.textContent = "More...";
-                resultItemParagraph.append(document.createTextNode(' '));
-                resultItemParagraph.append(blockLink);
-                resultItemParagraph.append(document.createElement('br'));
-              }
-              resultItem.append(resultItemParagraph);
-            });
-
-            // Add pagination
-            firstUrl = false;
-            if (data.next) {
-              fetchResults(data.next);
-            } else {
-              // Clear the interval when the search is complete
-              clearInterval(titleInterval);
-              pageTitle.text(originalTitle);
-            }
-          }
-        });
-      }
-
-      fetchResults(url);
+      versionReady.then(function(resolvedVersion) {
+        const url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}search/?q=project:${projectSlug}/${resolvedVersion}+${query}&page=${page + 1}&page_size=${count}`;
+        console.log(url);
+        DoxygenAwesomeReadtheDocsSearch.fetchResults(url, ctx);
+      });
     }
+  }
+
+  static _attachLiveSearch() {
+    let debounceTimer = null;
+
+    function onInput() {
+      clearTimeout(debounceTimer);
+      const field = document.getElementById('MSearchField');
+      if (!field) return;
+      const query = field.value.trim();
+      if (!query) {
+        DoxygenAwesomeReadtheDocsSearch._hideLiveResults();
+        return;
+      }
+      debounceTimer = setTimeout(function() {
+        DoxygenAwesomeReadtheDocsSearch._runLiveSearch(query);
+      }, 300);
+    }
+
+    function attachToField() {
+      const field = document.getElementById('MSearchField');
+      if (!field || field._rtdLiveSearchAttached) return;
+      field._rtdLiveSearchAttached = true;
+      field.setAttribute('autocomplete', 'off');
+      field.addEventListener('input', onInput);
+      field.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+          DoxygenAwesomeReadtheDocsSearch._hideLiveResults();
+        } else if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          DoxygenAwesomeReadtheDocsSearch._moveLiveResultFocus(1);
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          DoxygenAwesomeReadtheDocsSearch._moveLiveResultFocus(-1);
+        } else if (e.key === 'Enter') {
+          const focused = document.querySelector('#RTDLiveResults .rtd-live-item:focus');
+          if (focused) {
+            e.preventDefault();
+            focused.click();
+          }
+        }
+      });
+    }
+
+    attachToField();
+
+    // Re-attach when the DOM changes (e.g. menu.js recreates the field on mobile)
+    const fieldObserver = new MutationObserver(attachToField);
+    fieldObserver.observe(document.body, { childList: true, subtree: true });
+  }
+
+  static _runLiveSearch(query) {
+    const projectSlug = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-project-slug") || "doxyconfig";
+    const projectVersion = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-version-slug") || "latest";
+
+    const versionReady = /^\d+$/.test(projectVersion)
+        ? DoxygenAwesomeReadtheDocsSearch.getReadTheDocsDefaultVersion(projectSlug)
+        : Promise.resolve(projectVersion);
+
+    versionReady.then(function(resolvedVersion) {
+      const url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}search/?q=project:${projectSlug}/${resolvedVersion}+${query}&page=1&page_size=5`;
+      $.ajax({
+        url: url,
+        dataType: 'json',
+        success: function(data) {
+          DoxygenAwesomeReadtheDocsSearch._showLiveResults(query, data.results || []);
+        },
+        error: function() {
+          DoxygenAwesomeReadtheDocsSearch._hideLiveResults();
+        }
+      });
+    });
+  }
+
+  static _showLiveResults(query, results) {
+    let dropdown = document.getElementById('RTDLiveResults');
+    if (!dropdown) {
+      dropdown = document.createElement('div');
+      dropdown.id = 'RTDLiveResults';
+      document.body.appendChild(dropdown);
+    }
+
+    dropdown.innerHTML = '';
+
+    if (results.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'rtd-live-empty';
+      empty.textContent = 'No results found.';
+      dropdown.appendChild(empty);
+    } else {
+      const list = document.createElement('ul');
+      list.className = 'rtd-live-list';
+      for (const item of results) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.className = 'rtd-live-item';
+        a.href = `${item.domain}${item.path}`;
+        a.tabIndex = 0;
+
+        const title = document.createElement('span');
+        title.className = 'rtd-live-title';
+        title.textContent = item.title;
+        a.appendChild(title);
+
+        if (item.blocks && item.blocks.length > 0) {
+          const snippet = document.createElement('span');
+          snippet.className = 'rtd-live-snippet';
+          let snipHtml = item.blocks[0].highlights.content.join(' … ');
+          snipHtml = snipHtml.replaceAll(/<span>(.*?)<\/span>/g, '<mark>$1</mark>');
+          snippet.innerHTML = snipHtml;
+          a.appendChild(snippet);
+        }
+
+        li.appendChild(a);
+        list.appendChild(li);
+      }
+      dropdown.appendChild(list);
+    }
+
+    DoxygenAwesomeReadtheDocsSearch._positionLiveResults(dropdown);
+    dropdown.style.display = 'block';
+  }
+
+  static _positionLiveResults(dropdown) {
+    const field = document.getElementById('MSearchField');
+    const box = document.getElementById('MSearchBox');
+    const anchor = box || field;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const scrollY = window.scrollY;
+    const viewportWidth = document.documentElement.clientWidth;
+    dropdown.style.top = `${rect.bottom + scrollY}px`;
+    dropdown.style.left = '';
+    dropdown.style.right = `${viewportWidth - rect.right}px`;
+    dropdown.style.minWidth = `${Math.max(rect.width, 260)}px`;
+  }
+
+  static _hideLiveResults() {
+    const dropdown = document.getElementById('RTDLiveResults');
+    if (dropdown) {
+      dropdown.style.display = 'none';
+    }
+  }
+
+  static _moveLiveResultFocus(direction) {
+    const items = Array.from(document.querySelectorAll('#RTDLiveResults .rtd-live-item'));
+    if (items.length === 0) return;
+    const current = document.activeElement;
+    const idx = items.indexOf(current);
+    let next;
+    if (idx === -1) {
+      next = direction > 0 ? items[0] : items.at(-1);
+    } else {
+      next = items[idx + direction];
+    }
+    if (next) next.focus();
+  }
+
+  static fetchResults(url, ctx) {
+    $.ajax({
+      url: url,
+      dataType: 'json',
+      success: function(data) {
+        // Add the query to the search field
+        // This seems only be working if applied in the ajax success function...
+        // maybe the field is not available before this point
+        $('#MSearchField').val(ctx.query);
+
+        if (ctx.firstUrl) {
+          if (data.count === 1) {
+            ctx.resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[1];
+          } else if (data.count > 1) {
+            ctx.resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[2].replace(/\$num/, data.count);
+          } else {
+            ctx.resultSummary.innerHTML = DoxygenAwesomeReadtheDocsSearch.searchResultsText[0];
+          }
+          ctx.firstUrl = false;
+        }
+
+        $.each(data.results, function(i, item) {
+          DoxygenAwesomeReadtheDocsSearch.appendResultItem(ctx.resultList, item);
+        });
+
+        if (data.next) {
+          DoxygenAwesomeReadtheDocsSearch.fetchResults(data.next, ctx);
+        } else {
+          // Clear the interval when the search is complete
+          clearInterval(ctx.titleInterval);
+          ctx.pageTitle.text(ctx.originalTitle);
+        }
+      }
+    });
+  }
+
+  static appendResultItem(resultList, item) {
+    const resultItem = document.createElement('li');
+    resultItem.className = 'search-result';
+    const resultItemUrl = `${item.domain}${item.path}`;
+    const resultItemTitleLink = document.createElement('a');
+    const resultItemTitleHeading = document.createElement('h3');
+    resultItemTitleHeading.appendChild(resultItemTitleLink);
+    resultItemTitleLink.href = resultItemUrl;
+    resultItemTitleLink.textContent = item.title;
+    resultItem.append(resultItemTitleHeading);
+    resultList.append(resultItem);
+
+    const resultItemParagraph = document.createElement('p');
+    resultItemParagraph.className = 'context';
+    for (const block of item.blocks) {
+      let blockContent = block.highlights.content.join(', ');
+      blockContent = blockContent.replaceAll(/<span>(.*?)<\/span>/g, '<span class="highlighted">$1</span>');
+      resultItemParagraph.innerHTML += blockContent;
+
+      const blockName = `#${block.title.toLowerCase().replaceAll(' ', '-')}`;
+      const blockUrl = resultItemUrl + blockName;
+      const blockLink = document.createElement('a');
+      blockLink.href = blockUrl;
+      blockLink.textContent = "More...";
+      resultItemParagraph.append(document.createTextNode(' '));
+      resultItemParagraph.append(blockLink);
+      resultItemParagraph.append(document.createElement('br'));
+    }
+    resultItem.append(resultItemParagraph);
   }
 
   // Function to extract the value of a specified Read the Docs meta property
@@ -154,19 +369,22 @@ class DoxygenAwesomeReadtheDocsSearch {
   }
 
   static getReadTheDocsDefaultVersion(project) {
-    let url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}projects/${project}/`;
-    $.ajax({
-      url: url,
-      dataType: 'json',
-      success: function(data) {
-        console.log(data);
-        return data.default_version;
-      },
-      error: function(jqXHR, textStatus, errorThrown) {
-        console.error('Error:', textStatus, errorThrown);
-        console.log(`Cannot determine default version for ${project}, assuming "latest"`);
-        return "latest";
-      }
-    })
+    console.log('Pull request detected, getting default version from ReadTheDocs API');
+    const url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}projects/${project}/`;
+    return new Promise(function(resolve) {
+      $.ajax({
+        url: url,
+        dataType: 'json',
+        success: function(data) {
+          console.log(data);
+          resolve(data.default_version || 'latest');
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+          console.error('Error:', textStatus, errorThrown);
+          console.log(`Cannot determine default version for ${project}, assuming "latest"`);
+          resolve('latest');
+        }
+      });
+    });
   }
 }

--- a/doxygen-awesome-readthedocs-search.js
+++ b/doxygen-awesome-readthedocs-search.js
@@ -84,17 +84,17 @@ class DoxygenAwesomeReadtheDocsSearch {
     });
 
     globalThis.searchFor = function(query, page, count) {
-      const results = $('#searchresults');
+      const results = document.getElementById('searchresults');
 
       // Get the title
-      let pageTitle = $('div.title')
-      const originalTitle = pageTitle.text().toString();
+      const pageTitle = document.querySelector('div.title');
+      const originalTitle = pageTitle ? pageTitle.textContent : '';
       let pageTitleStates = ["Searching", "Searching .", "Searching ..", "Searching ..."];
       let pageTitleIndex = 0;
 
       // Function to update the page title
       function updatePageTitle() {
-        pageTitle.text(pageTitleStates[pageTitleIndex]);
+        if (pageTitle) pageTitle.textContent = pageTitleStates[pageTitleIndex];
         pageTitleIndex = (pageTitleIndex + 1) % pageTitleStates.length;
       }
 
@@ -104,12 +104,12 @@ class DoxygenAwesomeReadtheDocsSearch {
       // The summary will be displayed at the top of the search results
       let resultSummary = document.createElement('p');
       resultSummary.className = 'search-summary';
-      results.append(resultSummary);
+      results.appendChild(resultSummary);
 
       // Put all results into an unordered list
       let resultList = document.createElement('ul');
       resultList.className = 'search';
-      results.append(resultList);
+      results.appendChild(resultList);
 
       // readthedocs metadata
       let projectSlug = DoxygenAwesomeReadtheDocsSearch.getMetaValue("readthedocs-project-slug") || "doxygen-awesome-css";
@@ -191,16 +191,17 @@ class DoxygenAwesomeReadtheDocsSearch {
 
     versionReady.then(function(resolvedVersion) {
       const url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}search/?q=project:${projectSlug}/${resolvedVersion}+${query}&page=1&page_size=5`;
-      $.ajax({
-        url: url,
-        dataType: 'json',
-        success: function(data) {
+      fetch(url)
+        .then(function(response) {
+          if (!response.ok) throw new Error(response.statusText);
+          return response.json();
+        })
+        .then(function(data) {
           DoxygenAwesomeReadtheDocsSearch._showLiveResults(query, data.results || []);
-        },
-        error: function() {
+        })
+        .catch(function() {
           DoxygenAwesomeReadtheDocsSearch._hideLiveResults();
-        }
-      });
+        });
     });
   }
 
@@ -289,14 +290,17 @@ class DoxygenAwesomeReadtheDocsSearch {
   }
 
   static fetchResults(url, ctx) {
-    $.ajax({
-      url: url,
-      dataType: 'json',
-      success: function(data) {
+    fetch(url)
+      .then(function(response) {
+        if (!response.ok) throw new Error(response.statusText);
+        return response.json();
+      })
+      .then(function(data) {
         // Add the query to the search field
-        // This seems only be working if applied in the ajax success function...
+        // This seems only be working if applied in the fetch success handler...
         // maybe the field is not available before this point
-        $('#MSearchField').val(ctx.query);
+        const searchField = document.getElementById('MSearchField');
+        if (searchField) searchField.value = ctx.query;
 
         if (ctx.firstUrl) {
           if (data.count === 1) {
@@ -309,7 +313,7 @@ class DoxygenAwesomeReadtheDocsSearch {
           ctx.firstUrl = false;
         }
 
-        $.each(data.results, function(i, item) {
+        data.results.forEach(function(item) {
           DoxygenAwesomeReadtheDocsSearch.appendResultItem(ctx.resultList, item);
         });
 
@@ -318,10 +322,9 @@ class DoxygenAwesomeReadtheDocsSearch {
         } else {
           // Clear the interval when the search is complete
           clearInterval(ctx.titleInterval);
-          ctx.pageTitle.text(ctx.originalTitle);
+          if (ctx.pageTitle) ctx.pageTitle.textContent = ctx.originalTitle;
         }
-      }
-    });
+      });
   }
 
   static appendResultItem(resultList, item) {
@@ -371,20 +374,19 @@ class DoxygenAwesomeReadtheDocsSearch {
   static getReadTheDocsDefaultVersion(project) {
     console.log('Pull request detected, getting default version from ReadTheDocs API');
     const url = `${DoxygenAwesomeReadtheDocsSearch.serverUrl}projects/${project}/`;
-    return new Promise(function(resolve) {
-      $.ajax({
-        url: url,
-        dataType: 'json',
-        success: function(data) {
-          console.log(data);
-          resolve(data.default_version || 'latest');
-        },
-        error: function(jqXHR, textStatus, errorThrown) {
-          console.error('Error:', textStatus, errorThrown);
-          console.log(`Cannot determine default version for ${project}, assuming "latest"`);
-          resolve('latest');
-        }
+    return fetch(url)
+      .then(function(response) {
+        if (!response.ok) throw new Error(response.statusText);
+        return response.json();
+      })
+      .then(function(data) {
+        console.log(data);
+        return data.default_version || 'latest';
+      })
+      .catch(function(err) {
+        console.error('Error:', err);
+        console.log(`Cannot determine default version for ${project}, assuming "latest"`);
+        return 'latest';
       });
-    });
   }
 }

--- a/doxygen-awesome-readthedocs-search.js
+++ b/doxygen-awesome-readthedocs-search.js
@@ -4,6 +4,9 @@ class DoxygenAwesomeReadtheDocsSearch {
     "Search finished, found <b>1</b> page matching the search query.",
     "Search finished, found <b>$num</b> pages matching the search query.",
   ];
+  static _liveResultsAlignment = 'right';
+  static _liveResultsPositionFrame = null;
+  static _liveSearchAttached = false;
 
   static get serverUrl() {
     const serverUrlSuffix = '_/api/v3/';
@@ -21,7 +24,9 @@ class DoxygenAwesomeReadtheDocsSearch {
     return `https://${domainName}/${serverUrlSuffix}`;
   }
 
-  static init() {
+  static init(alignment = 'rightAlign') {
+    DoxygenAwesomeReadtheDocsSearch._liveResultsAlignment = alignment === 'leftAlign' ? 'left' : 'right';
+
     const realSearchBox = globalThis.SearchBox;
     globalThis.SearchBox = function(name, resultsPath, extension) {
       if (realSearchBox) {
@@ -133,6 +138,9 @@ class DoxygenAwesomeReadtheDocsSearch {
   }
 
   static _attachLiveSearch() {
+    if (DoxygenAwesomeReadtheDocsSearch._liveSearchAttached) return;
+    DoxygenAwesomeReadtheDocsSearch._liveSearchAttached = true;
+
     let debounceTimer = null;
 
     function onInput() {
@@ -155,23 +163,8 @@ class DoxygenAwesomeReadtheDocsSearch {
       field._rtdLiveSearchAttached = true;
       field.setAttribute('autocomplete', 'off');
       field.addEventListener('input', onInput);
-      field.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') {
-          DoxygenAwesomeReadtheDocsSearch._hideLiveResults();
-        } else if (e.key === 'ArrowDown') {
-          e.preventDefault();
-          DoxygenAwesomeReadtheDocsSearch._moveLiveResultFocus(1);
-        } else if (e.key === 'ArrowUp') {
-          e.preventDefault();
-          DoxygenAwesomeReadtheDocsSearch._moveLiveResultFocus(-1);
-        } else if (e.key === 'Enter') {
-          const focused = document.querySelector('#RTDLiveResults .rtd-live-item:focus');
-          if (focused) {
-            e.preventDefault();
-            focused.click();
-          }
-        }
-      });
+      field.addEventListener('keydown', DoxygenAwesomeReadtheDocsSearch._handleLiveSearchKeydown);
+      DoxygenAwesomeReadtheDocsSearch._scheduleLiveResultsPositionUpdate();
     }
 
     attachToField();
@@ -179,6 +172,8 @@ class DoxygenAwesomeReadtheDocsSearch {
     // Re-attach when the DOM changes (e.g. menu.js recreates the field on mobile)
     const fieldObserver = new MutationObserver(attachToField);
     fieldObserver.observe(document.body, { childList: true, subtree: true });
+
+    window.addEventListener('resize', DoxygenAwesomeReadtheDocsSearch._scheduleLiveResultsPositionUpdate);
   }
 
   static _runLiveSearch(query) {
@@ -210,6 +205,7 @@ class DoxygenAwesomeReadtheDocsSearch {
     if (!dropdown) {
       dropdown = document.createElement('div');
       dropdown.id = 'RTDLiveResults';
+      dropdown.addEventListener('keydown', DoxygenAwesomeReadtheDocsSearch._handleLiveSearchKeydown);
       document.body.appendChild(dropdown);
     }
 
@@ -260,23 +256,75 @@ class DoxygenAwesomeReadtheDocsSearch {
     const anchor = box || field;
     if (!anchor) return;
     const rect = anchor.getBoundingClientRect();
+    const scrollX = window.scrollX;
     const scrollY = window.scrollY;
     const viewportWidth = document.documentElement.clientWidth;
     dropdown.style.top = `${rect.bottom + scrollY}px`;
-    dropdown.style.left = '';
-    dropdown.style.right = `${viewportWidth - rect.right}px`;
+
+    if (window.matchMedia('(max-width: 767px)').matches) {
+      dropdown.style.left = '';
+      dropdown.style.right = '';
+      dropdown.style.minWidth = '';
+      return;
+    }
+
     dropdown.style.minWidth = `${Math.max(rect.width, 260)}px`;
+    if (DoxygenAwesomeReadtheDocsSearch._liveResultsAlignment === 'left') {
+      dropdown.style.left = `${rect.left + scrollX}px`;
+      dropdown.style.right = '';
+    } else {
+      dropdown.style.left = '';
+      dropdown.style.right = `${viewportWidth - rect.right}px`;
+    }
   }
 
-  static _hideLiveResults() {
+  static _hideLiveResults(restoreFocus = false) {
     const dropdown = document.getElementById('RTDLiveResults');
     if (dropdown) {
       dropdown.style.display = 'none';
     }
+    if (restoreFocus) {
+      const field = document.getElementById('MSearchField');
+      if (field) field.focus();
+    }
+  }
+
+  static _scheduleLiveResultsPositionUpdate() {
+    if (DoxygenAwesomeReadtheDocsSearch._liveResultsPositionFrame) return;
+    DoxygenAwesomeReadtheDocsSearch._liveResultsPositionFrame = window.requestAnimationFrame(function() {
+      DoxygenAwesomeReadtheDocsSearch._liveResultsPositionFrame = null;
+      DoxygenAwesomeReadtheDocsSearch._updateLiveResultsPosition();
+    });
+  }
+
+  static _updateLiveResultsPosition() {
+    const dropdown = document.getElementById('RTDLiveResults');
+    if (!dropdown || dropdown.style.display === 'none') return;
+    DoxygenAwesomeReadtheDocsSearch._positionLiveResults(dropdown);
+  }
+
+  static _handleLiveSearchKeydown(e) {
+    if (e.key === 'Escape') {
+      DoxygenAwesomeReadtheDocsSearch._hideLiveResults(true);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      DoxygenAwesomeReadtheDocsSearch._moveLiveResultFocus(1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      DoxygenAwesomeReadtheDocsSearch._moveLiveResultFocus(-1);
+    } else if (e.key === 'Enter') {
+      const focused = document.querySelector('#RTDLiveResults .rtd-live-item:focus');
+      if (focused) {
+        e.preventDefault();
+        focused.click();
+      }
+    }
   }
 
   static _moveLiveResultFocus(direction) {
-    const items = Array.from(document.querySelectorAll('#RTDLiveResults .rtd-live-item'));
+    const dropdown = document.getElementById('RTDLiveResults');
+    if (!dropdown || dropdown.style.display === 'none') return;
+    const items = Array.from(dropdown.querySelectorAll('.rtd-live-item'));
     if (items.length === 0) return;
     const current = document.activeElement;
     const idx = items.indexOf(current);

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+---
+name: RTD
+channels:
+  - conda-forge
+dependencies:
+  - doxygen=1.13.1
+  - graphviz=14.1.3

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+---
+name: RTD
+channels:
+  - conda-forge
+dependencies:
+  - doxygen=1.18.0
+  - graphviz=14.1.2

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "license": "MIT",
   "config": {},
-  "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "jquery": "^3.7.1"
+  },
   "xpack": {}
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
   },
   "license": "MIT",
   "config": {},
-  "devDependencies": {
-    "jquery": "^3.7.1"
-  },
   "xpack": {}
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,7 @@
   },
   "license": "MIT",
   "config": {},
+  "dependencies": {},
+  "devDependencies": {},
   "xpack": {}
 }

--- a/readthedocs_build.sh
+++ b/readthedocs_build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_dir="${READTHEDOCS_OUTPUT:-_readthedocs}"
+output_dir="${output_dir%/}"
+version="${READTHEDOCS_VERSION:-local}"
+canonical_url="${READTHEDOCS_CANONICAL_URL:-https://doxygen-awesome-css.readthedocs.io/}"
+
+mkdir -p "${output_dir}"
+
+rtd_doxyfile="${output_dir}/Doxyfile.readthedocs"
+rtd_header="${output_dir}/header.readthedocs.html"
+
+awk '
+  /<script type="text\/javascript" src="\$relpath\^doxygen-awesome-tabs\.js"><\/script>/ {
+    print
+    print "<script type=\"text/javascript\" src=\"$relpath^doxygen-awesome-readthedocs-search.js\"></script>"
+    next
+  }
+  /DoxygenAwesomeTabs\.init\(\)/ {
+    print
+    print "    // The RTD build uses the sidebar-only theme, so align live search results to the sidebar."
+    print "    DoxygenAwesomeReadtheDocsSearch.init('\''leftAlign'\'')"
+    next
+  }
+  { print }
+' doxygen-custom/header.html > "${rtd_header}"
+
+cp Doxyfile "${rtd_doxyfile}"
+cat >> "${rtd_doxyfile}" <<EOF
+
+# Read the Docs build overrides
+PROJECT_NUMBER = ${version}
+OUTPUT_DIRECTORY = ${output_dir}
+HTML_HEADER = ${rtd_header}
+HTML_EXTRA_FILES += doxygen-awesome-readthedocs-search.js
+HTML_EXTRA_STYLESHEET += doxygen-awesome-readthedocs-search.css
+SERVER_BASED_SEARCH = YES
+EXTERNAL_SEARCH = YES
+SEARCHENGINE_URL = ${canonical_url}
+EOF
+
+doxygen --version
+dot -V
+doxygen "${rtd_doxyfile}"


### PR DESCRIPTION
This PR adds a custom readthedocs search extension using javascript. I found the default doxygen search is quite terrible, and doesn't seem to actually search any markdown files (or barely searches them)... which is not great when you have user documentation.

I have added this for my own projects (here: https://github.com/LizardByte/doxyconfig/pull/4), and figured I could share it back here for others to benefit from. A live preview is available here: https://docs.lizardbyte.dev/projects/doxyconfig/latest/search.html?query=doxygen

This is what it looks like.
![image](https://github.com/user-attachments/assets/dc32cb6a-e45c-4f1f-9735-c702d44ee6d9)

![image](https://github.com/user-attachments/assets/25ad208b-428a-42e3-8888-aa39d4864cb9)


<details>
  <summary>Old version</summary>

   ![image](https://github.com/user-attachments/assets/e7a7d9de-27dd-499b-99fd-bca805129eca)

   ![image](https://github.com/user-attachments/assets/9b87cf22-eebc-4c28-a970-0951180ed1cc)
</details>

The styling is somewhat based on [Furo](https://github.com/pradyunsg/furo), this is how that looks in one of my projects.
![image](https://github.com/user-attachments/assets/6abaf736-dfe1-42cf-b6b4-39f9b5f7e3dc)


TODO:
- [x] improve the appearance/layout of the anchor urls
- [x] possibly add live searching (This is above my capability for now, maybe it could be part of a later PR).