### PR TITLE
feat: add ellipsis to text overflow in sidebar

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -805,6 +805,8 @@ html.dark-mode iframe#MSearchResults {
 #nav-tree .item {
     height: var(--tree-item-height);
     line-height: var(--tree-item-height);
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 #nav-tree .item > a:focus {
@@ -823,6 +825,8 @@ html.dark-mode iframe#MSearchResults {
     background-image: none;
     background-color: transparent;
     position: relative;
+    color: var(--primary-color) !important;
+    font-weight: 500;
 }
 
 #nav-tree .selected::after {


### PR DESCRIPTION
Currently, sidebar items don't display ellipses when overflowing. This is particularly problematic in the "sidebar-only" theme, where the sidebar cannot be resized, making it difficult to understand when items were truncated.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/1a915e5f-3b9d-46a5-aae1-a4d94472a388) | ![image](https://github.com/user-attachments/assets/af219b3d-a105-44f3-94e6-ed7f239f7fdf) |
|  ![image](https://github.com/user-attachments/assets/46f58146-b698-41d0-85b6-ff9f44669e16)| ![image](https://github.com/user-attachments/assets/3ce60047-273b-46d3-906f-fedf1e0a24b0) |

