### PR TITLE
feat: add support for "SHOW_ENUM_VALUES" option

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -1753,7 +1753,7 @@ table.fieldtable th {
     color: var(--tablehead-foreground);
 }
 
-table.fieldtable td.fieldtype, .fieldtable td.fieldname, .fieldtable td.fielddoc, .fieldtable th {
+table.fieldtable td.fieldtype, .fieldtable td.fieldname, .fieldtable td.fieldinit, .fieldtable td.fielddoc, .fieldtable th {
     border-bottom: 1px solid var(--separator-color);
     border-right: 1px solid var(--separator-color);
 }


### PR DESCRIPTION
Doxygen 1.12.0 introduced option "SHOW_ENUM_VALUES" that allow to print values of enumerations when they are explicitly defined. This PR add the new CSS identifier used for this field entry (which is `.fieldinit`):
- Before : 
![Capture d’écran du 2024-09-30 15-40-18](https://github.com/user-attachments/assets/d2d74416-058a-4ff8-8d60-30554c9deb43)
- After : 
![Capture d’écran du 2024-09-30 15-39-50](https://github.com/user-attachments/assets/1142f3ba-416c-492b-9191-95176974adff)
