### PR TITLE
docs: add example website OpenRemise doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Some websites using this theme:
 - [libCloudSync](https://jothepro.github.io/libCloudSync/)
 - [libsl3](https://a4z.github.io/libsl3/)
 - [DuMu<sup>x</sup>](https://dumux.org/docs/doxygen/master/)
+- [OpenRemise](https://openremise.at/)
 
 ## Installation
 


### PR DESCRIPTION
I'm extensively using doxygen-awesome in an open source hard/software project for model trains.
The projects can be found here: https://openremise.at/

Not only is the entire software documented using doxygen-awesome, but I also did the projects "landing page" with it so that the entire project website has a consistent look.