### PR TITLE
fix: replace jQuery ready wrappers with native init

### DIFF
--- a/doxygen-awesome-darkmode-toggle.js
+++ b/doxygen-awesome-darkmode-toggle.js
@@ -37,29 +37,31 @@ class DoxygenAwesomeDarkModeToggle extends HTMLElement {
     }()
 
     static init() {
-        $(function() {
-            $(document).ready(function() {
-                const toggleButton = document.createElement('doxygen-awesome-dark-mode-toggle')
-                toggleButton.title = DoxygenAwesomeDarkModeToggle.title
+        const initToggle = () => {
+            const toggleButton = document.createElement('doxygen-awesome-dark-mode-toggle')
+            toggleButton.title = DoxygenAwesomeDarkModeToggle.title
+            toggleButton.updateIcon()
+
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
                 toggleButton.updateIcon()
-
-                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-                    toggleButton.updateIcon()
-                })
-                document.addEventListener("visibilitychange", visibilityState => {
-                    if (document.visibilityState === 'visible') {
-                        toggleButton.updateIcon()
-                    }
-                });
-
-                $(document).ready(function(){
-                    document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
-                })
-                $(window).resize(function(){
-                    document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
-                })
             })
-        })
+            document.addEventListener("visibilitychange", visibilityState => {
+                if (document.visibilityState === 'visible') {
+                    toggleButton.updateIcon()
+                }
+            });
+
+            document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
+            window.addEventListener("resize", () => {
+                document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
+            })
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", initToggle)
+        } else {
+            initToggle()
+        }
     }
 
     constructor() {

--- a/doxygen-awesome-fragment-copy-button.js
+++ b/doxygen-awesome-fragment-copy-button.js
@@ -18,25 +18,28 @@ class DoxygenAwesomeFragmentCopyButton extends HTMLElement {
     static successIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M8.084,16.111c-0.09,0.09 -0.212,0.141 -0.34,0.141c-0.127,-0 -0.249,-0.051 -0.339,-0.141c-0.746,-0.746 -2.538,-2.538 -3.525,-3.525c-0.375,-0.375 -0.983,-0.375 -1.357,0c-0.178,0.178 -0.369,0.369 -0.547,0.547c-0.375,0.375 -0.375,0.982 -0,1.357c1.135,1.135 3.422,3.422 4.75,4.751c0.27,0.27 0.637,0.421 1.018,0.421c0.382,0 0.749,-0.151 1.019,-0.421c2.731,-2.732 10.166,-10.167 12.454,-12.455c0.375,-0.375 0.375,-0.982 -0,-1.357c-0.178,-0.178 -0.369,-0.369 -0.547,-0.547c-0.375,-0.375 -0.982,-0.375 -1.357,0c-2.273,2.273 -9.567,9.567 -11.229,11.229Z"/></svg>`
     static successDuration = 980
     static init() {
-        $(function() {
-            $(document).ready(function() {
-                if(navigator.clipboard) {
-                    const fragments = document.getElementsByClassName("fragment")
-                    for(const fragment of fragments) {
-                        const fragmentWrapper = document.createElement("div")
-                        fragmentWrapper.className = "doxygen-awesome-fragment-wrapper"
-                        const fragmentCopyButton = document.createElement("doxygen-awesome-fragment-copy-button")
-                        fragmentCopyButton.innerHTML = DoxygenAwesomeFragmentCopyButton.copyIcon
-                        fragmentCopyButton.title = DoxygenAwesomeFragmentCopyButton.title
-                
-                        fragment.parentNode.replaceChild(fragmentWrapper, fragment)
-                        fragmentWrapper.appendChild(fragment)
-                        fragmentWrapper.appendChild(fragmentCopyButton)
-            
-                    }
+        const initCopyButtons = () => {
+            if(navigator.clipboard) {
+                const fragments = document.getElementsByClassName("fragment")
+                for(const fragment of fragments) {
+                    const fragmentWrapper = document.createElement("div")
+                    fragmentWrapper.className = "doxygen-awesome-fragment-wrapper"
+                    const fragmentCopyButton = document.createElement("doxygen-awesome-fragment-copy-button")
+                    fragmentCopyButton.innerHTML = DoxygenAwesomeFragmentCopyButton.copyIcon
+                    fragmentCopyButton.title = DoxygenAwesomeFragmentCopyButton.title
+
+                    fragment.parentNode.replaceChild(fragmentWrapper, fragment)
+                    fragmentWrapper.appendChild(fragment)
+                    fragmentWrapper.appendChild(fragmentCopyButton)
                 }
-            })
-        })
+            }
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", initCopyButtons)
+        } else {
+            initCopyButtons()
+        }
     }
 
 

--- a/doxygen-awesome-paragraph-link.js
+++ b/doxygen-awesome-paragraph-link.js
@@ -15,18 +15,22 @@ class DoxygenAwesomeParagraphLink {
     static icon = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M17 7h-4v2h4c1.65 0 3 1.35 3 3s-1.35 3-3 3h-4v2h4c2.76 0 5-2.24 5-5s-2.24-5-5-5zm-6 8H7c-1.65 0-3-1.35-3-3s1.35-3 3-3h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-2zm-3-4h8v2H8z"/></svg>`
     static title = "Permanent Link"
     static init() {
-        $(function() {
-            $(document).ready(function() {
-                document.querySelectorAll(".contents a.anchor[id], .contents .groupheader > a[id]").forEach((node) => {
-                    let anchorlink = document.createElement("a")
-                    anchorlink.setAttribute("href", `#${node.getAttribute("id")}`)
-                    anchorlink.setAttribute("title", DoxygenAwesomeParagraphLink.title)
-                    anchorlink.classList.add("anchorlink")
-                    node.classList.add("anchor")
-                    anchorlink.innerHTML = DoxygenAwesomeParagraphLink.icon
-                    node.parentElement.appendChild(anchorlink)
-                })
+        const initParagraphLinks = () => {
+            document.querySelectorAll(".contents a.anchor[id], .contents .groupheader > a[id]").forEach((node) => {
+                let anchorlink = document.createElement("a")
+                anchorlink.setAttribute("href", `#${node.getAttribute("id")}`)
+                anchorlink.setAttribute("title", DoxygenAwesomeParagraphLink.title)
+                anchorlink.classList.add("anchorlink")
+                node.classList.add("anchor")
+                anchorlink.innerHTML = DoxygenAwesomeParagraphLink.icon
+                node.parentElement.appendChild(anchorlink)
             })
-        })
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", initParagraphLinks)
+        } else {
+            initParagraphLinks()
+        }
     }
 }


### PR DESCRIPTION
Refactors the dark mode toggle, fragment copy button, and paragraph link scripts to use native DOM readiness checks (`DOMContentLoaded` / immediate execution) instead of nested `$(document).ready(...)` wrappers. This removes jQuery-dependent initialization paths and keeps behavior consistent when scripts run before or after document load, while preserving existing UI wiring like dark mode icon updates and resize reattachment.

This is required for Doxygen 1.17+ because they stopped bundling jQuery.